### PR TITLE
fix: Fix test with new opencontrol version 

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -18,7 +18,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
-        ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}        
+        ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
         ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/housekeeping.sh
 
   linting:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Install Python dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -1253,8 +1253,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<3.10"
-content-hash = "c75158ab55f526b8d78628a4ba374591b720ba58b219e8268cc3ae0867f781fa"
+python-versions = ">=3.7,<3.9"
+content-hash = "d6a1914170fdc3136665ad737015d82b3a34e33662c2fa9c190a5a9389cdb2b0"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ license = "Apache-2.0"
 authors = ["Q-CTRL <support@q-ctrl.com>"]
 readme = "README.md"
 keywords = [
-    "quantum", 
-    "computing", 
-    "open source", 
+    "quantum",
+    "computing",
+    "open source",
     "engineering",
     "qiskit"
 ]
@@ -33,7 +33,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]  # https://poetry.eustace.io/docs/versions
-python = ">=3.7,<3.10"
+python = ">=3.7,<3.9"
 numpy = "^1.16"
 scipy = "^1.3"
 toml = "^0.10.0"
@@ -50,6 +50,11 @@ pylint_runner = "*"
 sphinx = "^2.2.0"
 nbval = "^0.9.5"
 qctrl-visualizer = "^2.12.1"
+isort = "^5.7.0"
+
+[tool.isort]
+profile = "black"
+force_grid_wrap = "2"
 
 [tool.dephell.main]
 from = {format = "poetry", path = "pyproject.toml"}
@@ -70,4 +75,3 @@ build-backend = "poetry.masonry.api"
 #            (__)\       )\/\
 #                ||----w |
 #                ||     ||
-

--- a/qctrlqiskit/quantum_circuit.py
+++ b/qctrlqiskit/quantum_circuit.py
@@ -19,7 +19,11 @@ qiskit.quantum_circuit
 import numpy as np
 from qctrlopencontrols import DynamicDecouplingSequence
 from qctrlopencontrols.exceptions import ArgumentsValueError
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import (
+    ClassicalRegister,
+    QuantumCircuit,
+    QuantumRegister,
+)
 from qiskit.qasm import pi
 
 FIX_DURATION_UNITARY = "fixed duration unitary"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name='qctrl-qiskit',
     version='0.0.3',
     description='Q-CTRL Qiskit Adapter',
-    python_requires='<3.10,>=3.7',
+    python_requires='<3.9,>=3.7',
     project_urls={"repository": "https://github.com/qctrl/python-qiskit"},
     author='Q-CTRL',
     author_email='support@q-ctrl.com',
@@ -37,5 +37,5 @@ setup(
     package_dir={"": "."},
     package_data={},
     install_requires=['numpy==1.*,>=1.16.0', 'qctrl-open-controls==8.*,>=8.5.1', 'qiskit-ibmq-provider==0.*,>=0.3.3', 'qiskit-terra==0.*,>=0.12.0', 'scipy==1.*,>=1.3.0', 'toml==0.*,>=0.10.0'],
-    extras_require={"dev": ["nbval==0.*,>=0.9.5", "pylama", "pylint", "pylint-runner", "pytest", "qctrl-visualizer==2.*,>=2.12.1", "sphinx==2.*,>=2.2.0"]},
+    extras_require={"dev": ["isort==5.*,>=5.7.0", "nbval==0.*,>=0.9.5", "pylama", "pylint", "pylint-runner", "pytest", "qctrl-visualizer==2.*,>=2.12.1", "sphinx==2.*,>=2.2.0"]},
 )

--- a/tests/test_qiskit_sequence.py
+++ b/tests/test_qiskit_sequence.py
@@ -17,13 +17,23 @@ Tests conversion to Qiskit Circuit
 """
 
 import numpy as np
-from qctrlopencontrols import (new_carr_purcell_sequence, new_cpmg_sequence,
-                               new_periodic_sequence, new_quadratic_sequence,
-                               new_spin_echo_sequence, new_uhrig_sequence,
-                               new_walsh_sequence, new_x_concatenated_sequence,
-                               new_xy_concatenated_sequence)
+from qctrlopencontrols import (
+    new_carr_purcell_sequence,
+    new_cpmg_sequence,
+    new_periodic_sequence,
+    new_quadratic_sequence,
+    new_spin_echo_sequence,
+    new_uhrig_sequence,
+    new_walsh_sequence,
+    new_x_concatenated_sequence,
+    new_xy_concatenated_sequence,
+)
+from qiskit import (
+    BasicAer,
+    execute,
+)
+
 from qctrlqiskit import convert_dds_to_qiskit_quantum_circuit
-from qiskit import BasicAer, execute
 
 _callable = {
     "Spin echo": new_spin_echo_sequence,

--- a/tests/test_qiskit_sequence.py
+++ b/tests/test_qiskit_sequence.py
@@ -13,23 +13,46 @@
 # limitations under the License.
 
 """
-===================================
 Tests conversion to Qiskit Circuit
-===================================
 """
 
 import numpy as np
+from qctrlopencontrols import (
+    new_carr_purcell_sequence,
+    new_cpmg_sequence,
+    new_periodic_sequence,
+    new_quadratic_sequence,
+    new_spin_echo_sequence,
+    new_uhrig_sequence,
+    new_walsh_sequence,
+    new_x_concatenated_sequence,
+    new_xy_concatenated_sequence,
+)
+from qiskit import (
+    BasicAer,
+    execute,
+)
 
-from qiskit import execute
-from qiskit import BasicAer
-
-from qctrlopencontrols import new_predefined_dds
 from qctrlqiskit import convert_dds_to_qiskit_quantum_circuit
+
+_callable = {
+    "Spin echo": new_spin_echo_sequence,
+    "Carr-Purcell": new_carr_purcell_sequence,
+    "Carr-Purcell-Meiboom-Gill": new_cpmg_sequence,
+    "Uhrig single-axis": new_uhrig_sequence,
+    "periodic single-axis": new_periodic_sequence,
+    "Periodic single-axis": new_periodic_sequence,
+    "Walsh single-axis": new_walsh_sequence,
+    "Quadratic": new_quadratic_sequence,
+    "X concatenated": new_x_concatenated_sequence,
+    "XY concatenated": new_xy_concatenated_sequence,
+}
 
 
 def _create_test_sequence(sequence_scheme, pre_post_rotation):
 
-    """Create a DD sequence of choice'''
+    """
+    Create a DD sequence of choice.
 
     Parameters
     ----------
@@ -48,62 +71,71 @@ def _create_test_sequence(sequence_scheme, pre_post_rotation):
         schema information
     """
 
-    dd_sequence_params = dict()
-    dd_sequence_params['scheme'] = sequence_scheme
-    dd_sequence_params['duration'] = 4
-    dd_sequence_params['pre_post_rotation'] = pre_post_rotation
+    dd_sequence_params = {}
+    dd_sequence_params["duration"] = 4
+    dd_sequence_params["pre_post_rotation"] = pre_post_rotation
 
     # 'spin_echo' does not need any additional parameter
 
-    if dd_sequence_params['scheme'] in ['Carr-Purcell', 'Carr-Purcell-Meiboom-Gill',
-                                        'Uhrig single-axis', 'periodic single-axis']:
+    if sequence_scheme in [
+        "Carr-Purcell",
+        "Carr-Purcell-Meiboom-Gill",
+        "Uhrig single-axis",
+        "periodic single-axis",
+    ]:
 
-        dd_sequence_params['number_of_offsets'] = 2
+        dd_sequence_params["offset_count"] = 2
 
-    elif dd_sequence_params['scheme'] in ['Walsh single-axis']:
+    elif sequence_scheme in ["Walsh single-axis"]:
 
-        dd_sequence_params['paley_order'] = 5
+        dd_sequence_params["paley_order"] = 5
 
-    elif dd_sequence_params['scheme'] in ['quadratic']:
+    elif sequence_scheme in ["quadratic"]:
 
-        dd_sequence_params['duration'] = 16
-        dd_sequence_params['number_outer_offsets'] = 4
-        dd_sequence_params['number_inner_offsets'] = 4
+        dd_sequence_params["duration"] = 16
+        dd_sequence_params["outer_offset_count"] = 4
+        dd_sequence_params["inner_offset_count"] = 4
 
-    elif dd_sequence_params['scheme'] in ['X concatenated',
-                                          'XY concatenated']:
+    elif sequence_scheme in ["X concatenated", "XY concatenated"]:
 
-        dd_sequence_params['duration'] = 16
-        dd_sequence_params['concatenation_order'] = 2
+        dd_sequence_params["duration"] = 16
+        dd_sequence_params["concatenation_order"] = 2
 
-    sequence = new_predefined_dds(**dd_sequence_params)
+    sequence = _callable[sequence_scheme](**dd_sequence_params)
     return sequence
 
 
 def _check_circuit_unitary(pre_post_rotation, algorithm):
-    """Checks that the unitary of a dynamic decoupling operation is the identity
+    """
+    Checks that the unitary of a dynamic decoupling operation is the identity.
     """
 
-    backend = 'unitary_simulator'
+    backend = "unitary_simulator"
     number_of_shots = 1
     backend_simulator = BasicAer.get_backend(backend)
 
-    for sequence_scheme in ['Carr-Purcell', 'Carr-Purcell-Meiboom-Gill',
-                            'Uhrig single-axis', 'periodic single-axis', 'Walsh single-axis',
-                            'quadratic', 'X concatenated',
-                            'XY concatenated']:
+    for sequence_scheme in [
+        "Carr-Purcell",
+        "Carr-Purcell-Meiboom-Gill",
+        "Uhrig single-axis",
+        "periodic single-axis",
+        "Walsh single-axis",
+        "quadratic",
+        "X concatenated",
+        "XY concatenated",
+    ]:
         sequence = _create_test_sequence(sequence_scheme, pre_post_rotation)
         quantum_circuit = convert_dds_to_qiskit_quantum_circuit(
             dynamic_decoupling_sequence=sequence,
-            add_measurement=False, algorithm=algorithm)
+            add_measurement=False,
+            algorithm=algorithm,
+        )
 
-        job = execute(quantum_circuit,
-                      backend_simulator,
-                      shots=number_of_shots)
+        job = execute(quantum_circuit, backend_simulator, shots=number_of_shots)
         result = job.result()
         unitary = result.get_unitary(quantum_circuit)
 
-        assert np.isclose(np.abs(np.trace(unitary)), 2.)
+        assert np.isclose(np.abs(np.trace(unitary)), 2.0)
 
 
 def test_identity_operation():
@@ -111,14 +143,14 @@ def test_identity_operation():
     """Tests if the Dynamic Decoupling Sequence gives rise to Identity
     operation in Qiskit
     """
-    _check_circuit_unitary(False, 'instant unitary')
+    _check_circuit_unitary(False, "instant unitary")
 
-    _check_circuit_unitary(True, 'instant unitary')
+    _check_circuit_unitary(True, "instant unitary")
 
-    _check_circuit_unitary(False, 'fixed duration unitary')
+    _check_circuit_unitary(False, "fixed duration unitary")
 
-    _check_circuit_unitary(True, 'fixed duration unitary')
+    _check_circuit_unitary(True, "fixed duration unitary")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass

--- a/tests/test_qiskit_sequence.py
+++ b/tests/test_qiskit_sequence.py
@@ -17,23 +17,13 @@ Tests conversion to Qiskit Circuit
 """
 
 import numpy as np
-from qctrlopencontrols import (
-    new_carr_purcell_sequence,
-    new_cpmg_sequence,
-    new_periodic_sequence,
-    new_quadratic_sequence,
-    new_spin_echo_sequence,
-    new_uhrig_sequence,
-    new_walsh_sequence,
-    new_x_concatenated_sequence,
-    new_xy_concatenated_sequence,
-)
-from qiskit import (
-    BasicAer,
-    execute,
-)
-
+from qctrlopencontrols import (new_carr_purcell_sequence, new_cpmg_sequence,
+                               new_periodic_sequence, new_quadratic_sequence,
+                               new_spin_echo_sequence, new_uhrig_sequence,
+                               new_walsh_sequence, new_x_concatenated_sequence,
+                               new_xy_concatenated_sequence)
 from qctrlqiskit import convert_dds_to_qiskit_quantum_circuit
+from qiskit import BasicAer, execute
 
 _callable = {
     "Spin echo": new_spin_echo_sequence,
@@ -41,7 +31,7 @@ _callable = {
     "Carr-Purcell-Meiboom-Gill": new_cpmg_sequence,
     "Uhrig single-axis": new_uhrig_sequence,
     "periodic single-axis": new_periodic_sequence,
-    "Periodic single-axis": new_periodic_sequence,
+    "quadratic": new_quadratic_sequence,
     "Walsh single-axis": new_walsh_sequence,
     "Quadratic": new_quadratic_sequence,
     "X concatenated": new_x_concatenated_sequence,


### PR DESCRIPTION
Code and tests should be working with the latest version of open control now.

However, note that the qisikt-related pkgs are all locked to some very old versions:
- `qiskit-terra (0.12.0)` (latest is 0.18.3) doesn't support Python 3.9. 
- `qiskit-ibmq-provider` is 0.3.3 and latest is 0.18.1.

Updating to the latest version would require more change to the actual code, not just the test.
I am not sure if we want to do it. Any thought? @Jacqueslee @leoadec 